### PR TITLE
Fix rack url scheme

### DIFF
--- a/lib/opencensus/trace/integrations/rack_middleware.rb
+++ b/lib/opencensus/trace/integrations/rack_middleware.rb
@@ -103,7 +103,7 @@ module OpenCensus
         def get_url env
           path = get_path env
           host = get_host env
-          scheme = env["SERVER_PROTOCOL"]
+          scheme = env["rack.url_scheme"]
           query_string = env["QUERY_STRING"].to_s
           url = "#{scheme}://#{host}#{path}"
           url = "#{url}?#{query_string}" unless query_string.empty?


### PR DESCRIPTION
This fixes the `http/url` key. In rack env, `SERVER_PROTOCOL` corresponds to the http protocol version, e.g. `HTTP/1.1`. Thus, it currently produces an URL that looks like: `HTTP/1.1://example.org/foo`.

The scheme (`http` or `https`) is contained in the rack env under `rack.url_scheme`.